### PR TITLE
Fix `yarn flow-check-...` commands

### DIFF
--- a/.flowconfig.macos
+++ b/.flowconfig.macos
@@ -34,9 +34,6 @@ flow/
 [options]
 emoji=true
 
-esproposal.optional_chaining=enable
-esproposal.nullish_coalescing=enable
-
 exact_by_default=true
 
 module.file_ext=.js
@@ -55,8 +52,6 @@ suppress_type=$FlowFixMeProps
 suppress_type=$FlowFixMeState
 suppress_type=$FlowFixMeEmpty
 
-well_formed_exports=true
-types_first=true
 experimental.abstract_locations=true
 
 [lints]
@@ -81,4 +76,4 @@ untyped-import
 untyped-type-import
 
 [version]
-^0.137.0
+^0.158.0

--- a/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
+++ b/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
@@ -30,6 +30,7 @@ type AccessibilityEventDefinitionsIOS = {
 
 type AccessibilityEventDefinitions = {
   ...AccessibilityEventDefinitionsIOS,
+  highContrastChanged: [boolean], // TODO(macOS GH#774) - highContrastChanged is used on macOS
   change: [boolean], // screenReaderChanged
   reduceMotionChanged: [boolean],
   screenReaderChanged: [boolean],

--- a/Libraries/Components/AccessibilityInfo/legacySendAccessibilityEvent.macos.js
+++ b/Libraries/Components/AccessibilityInfo/legacySendAccessibilityEvent.macos.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ */
+
+// TODO(macOS GH#774)
+
+/* $FlowFixMe allow macOS to share iOS file */
+const legacySendAccessibilityEvent = require('./legacySendAccessibilityEvent.ios');
+
+module.exports = legacySendAccessibilityEvent;

--- a/Libraries/Components/Button.js
+++ b/Libraries/Components/Button.js
@@ -23,9 +23,10 @@ import type {KeyEvent} from '../Types/CoreEventTypes'; // TODO(OSS Candidate ISS
 import type {FocusEvent, BlurEvent} from './TextInput/TextInput'; // TODO(OSS Candidate ISS#2710739)
 
 import type {
-  AccessibilityState,
   AccessibilityActionEvent,
   AccessibilityActionInfo,
+  AccessibilityRole,
+  AccessibilityState,
 } from './View/ViewAccessibility';
 import type {PressEvent} from '../Types/CoreEventTypes';
 

--- a/Libraries/Components/View/ViewAccessibility.js
+++ b/Libraries/Components/View/ViewAccessibility.js
@@ -47,6 +47,7 @@ export type AccessibilityRole =
   | 'tabbar'
   | 'tablist'
   | 'timer'
+  | 'list'
   | 'toolbar'
   | 'popupbutton'
   | 'menubutton'; // TODO(macOS GH#774)

--- a/Libraries/Lists/FlatList.js
+++ b/Libraries/Lists/FlatList.js
@@ -617,7 +617,7 @@ class FlatList<ItemT> extends React.PureComponent<Props<ItemT>, void> {
                 const element = renderer({
                   item: it,
                   index: index * numColumns + kk,
-                  // isSelected: info.isSelected, // TODO(macOS GH#774) // TODO(macOS add back selection support for 66 merge)
+                  isSelected: info.isSelected, // TODO(macOS GH#774)
                   separators: info.separators,
                 });
                 return element != null ? (

--- a/Libraries/Lists/SectionList.js
+++ b/Libraries/Lists/SectionList.js
@@ -47,7 +47,7 @@ type OptionalProps<SectionT: SectionBase<any>> = {|
   renderItem?: (info: {
     item: Item,
     index: number,
-    // isSelected?: boolean, // TODO(macOS GH#774) // TODO(macOS add back selection support for 66 merge)
+    isSelected?: boolean, // TODO(macOS GH#774)
     section: SectionT,
     separators: {
       highlight: () => void,

--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -56,7 +56,7 @@ export type Separators = {
 export type RenderItemProps<ItemT> = {
   item: ItemT,
   index: number,
-  // isSelected: ?boolean, // TODO(macOS GH#774) // TODO(macOS add back selection support for 66 merge)
+  isSelected: ?boolean, // TODO(macOS GH#774)
   separators: Separators,
   ...
 };
@@ -75,12 +75,11 @@ type ViewabilityHelperCallbackTuple = {
   ...
 };
 
-// TODO(macOS add back selection support for 66 merge)
 // [TODO(macOS GH#774)
-// export type SelectedRowIndexPathType = {
-//   sectionIndex: number,
-//   rowIndex: number,
-// }; // ]TODO(macOS GH#774)
+export type SelectedRowIndexPathType = {
+  sectionIndex: number,
+  rowIndex: number,
+}; // ]TODO(macOS GH#774)
 
 type RequiredProps = {|
   /**
@@ -883,7 +882,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
           index={ii}
           inversionStyle={inversionStyle}
           item={item}
-          // isSelected={this.state.selectedRowIndex === ii ? true : false} // TODO(macOS GH#774) // TODO(macOS add back selection support for 66 merge)
+          isSelected={this.state.selectedRowIndex === ii ? true : false} // TODO(macOS GH#774)
           key={key}
           prevCellKey={prevCellKey}
           onUpdateSeparators={this._onUpdateSeparators}
@@ -2069,7 +2068,7 @@ type CellRendererProps = {
   horizontal: ?boolean,
   index: number,
   inversionStyle: ViewStyleProp,
-  // isSelected: ?boolean, // TODO(macOS GH#774) // TODO(macOS add back selection support for 66 merge)
+  isSelected: ?boolean, // TODO(macOS GH#774)
   item: Item,
   // This is extracted by ScrollViewStickyHeader
   onLayout: (event: Object) => void,
@@ -2164,7 +2163,7 @@ class CellRenderer extends React.Component<
     ListItemComponent,
     item,
     index,
-    // isSelected /* TODO(macOS GH#774 */, // TODO(macOS add back selection support for 66 merge)
+    isSelected, // TODO(macOS GH#774)
   ) {
     if (renderItem && ListItemComponent) {
       console.warn(
@@ -2191,7 +2190,7 @@ class CellRenderer extends React.Component<
       return renderItem({
         item,
         index,
-        // isSelected, // TODO(macOS GH#774) // TODO(macOS add back selection support for 66 merge)
+        isSelected, // TODO(macOS GH#774)
         separators: this._separators,
       });
     }

--- a/Libraries/Lists/VirtualizedSectionList.js
+++ b/Libraries/Lists/VirtualizedSectionList.js
@@ -11,7 +11,7 @@
 const Platform = require('../Utilities/Platform'); // TODO(macOS GH#774)
 import invariant from 'invariant';
 import type {ViewToken} from './ViewabilityHelper';
-// import type {SelectedRowIndexPathType} from './VirtualizedList'; // TODO(macOS GH#774)
+import type {SelectedRowIndexPathType} from './VirtualizedList'; // TODO(macOS GH#774)
 import type {ScrollEvent} from '../Types/CoreEventTypes'; // TODO(macOS GH#774)
 import {keyExtractor as defaultKeyExtractor} from './VirtualizeUtils';
 import {View, VirtualizedList} from 'react-native';
@@ -65,7 +65,7 @@ type OptionalProps<SectionT: SectionBase<any>> = {|
   renderItem?: (info: {
     item: Item,
     index: number,
-    // isSelected?: boolean, // TODO(macOS GH#774)
+    isSelected?: boolean, // TODO(macOS GH#774)
     section: SectionT,
     separators: {
       highlight: () => void,
@@ -146,7 +146,8 @@ export type ScrollToLocationParamsType = {|
 |};
 
 type State = {
-  childProps: VirtualizedListProps /*TODO(macOS GH#774)*/ /*selectedRowIndexPath: SelectedRowIndexPathType, */,
+  childProps: VirtualizedListProps,
+  selectedRowIndexPath: SelectedRowIndexPathType, // TODO(macOS GH#774)
   ...
 };
 
@@ -233,116 +234,116 @@ class VirtualizedSectionList<
             ? this._onViewableItemsChanged
             : undefined
         }
-        // selectedRowIndexPath={{sectionIndex: 0, rowIndex: -1}} // TODO(macOS GH#774) // TODO(macOS add back selection support for 66 merge)
-        // {...this.state.selectedRowIndexPath} // TODO(macOS GH#774) // TODO(macOS add back selection support for 66 merge)
+        {...this.state.selectedRowIndexPath} // TODO(macOS GH#774)
         ref={this._captureRef}
       />
     );
   }
 
-  // TODO(macOS add back selection support for 66 merge)
   // [TODO(macOS GH#774)
-  // _selectRowAboveIndexPath = rowIndexPath => {
-  //   let sectionIndex = rowIndexPath.sectionIndex;
-  //   if (sectionIndex >= this.props.sections.length) {
-  //     return rowIndexPath;
-  //   }
+  _selectRowAboveIndexPath = rowIndexPath => {
+    let sectionIndex = rowIndexPath.sectionIndex;
+    if (sectionIndex >= this.props.sections.length) {
+      return rowIndexPath;
+    }
 
-  //   let row = rowIndexPath.rowIndex;
-  //   let rowAbove = row - 1;
+    let row = rowIndexPath.rowIndex;
+    let rowAbove = row - 1;
 
-  //   if (rowAbove < 0) {
-  //     if (sectionIndex > 0) {
-  //       sectionIndex = sectionIndex - 1;
-  //       rowAbove = Math.max(
-  //         0,
-  //         this.props.sections[sectionIndex].data.length - 1,
-  //       );
-  //     } else {
-  //       rowAbove = row;
-  //     }
-  //   }
-  //   const nextIndexPath = {sectionIndex: sectionIndex, rowIndex: rowAbove};
-  //   this.setState(state => {
-  //     return {selectedRowIndexPath: nextIndexPath};
-  //   });
-  //   return nextIndexPath;
-  // };
+    if (rowAbove < 0) {
+      if (sectionIndex > 0) {
+        sectionIndex = sectionIndex - 1;
+        rowAbove = Math.max(
+          0,
+          this.props.sections[sectionIndex].data.length - 1,
+        );
+      } else {
+        rowAbove = row;
+      }
+    }
+    const nextIndexPath = {sectionIndex: sectionIndex, rowIndex: rowAbove};
+    this.setState(state => {
+      return {selectedRowIndexPath: nextIndexPath};
+    });
+    return nextIndexPath;
+  };
 
-  // _selectRowBelowIndexPath = rowIndexPath => {
-  //   let sectionIndex = rowIndexPath.sectionIndex;
-  //   if (sectionIndex >= this.props.sections.length) {
-  //     return rowIndexPath;
-  //   }
+  _selectRowBelowIndexPath = rowIndexPath => {
+    let sectionIndex = rowIndexPath.sectionIndex;
+    if (sectionIndex >= this.props.sections.length) {
+      return rowIndexPath;
+    }
 
-  //   const count = this.props.sections[sectionIndex].data.length;
-  //   let row = rowIndexPath.rowIndex;
-  //   let rowBelow = row + 1;
+    const count = this.props.sections[sectionIndex].data.length;
+    let row = rowIndexPath.rowIndex;
+    let rowBelow = row + 1;
 
-  //   if (rowBelow > count - 1) {
-  //     if (sectionIndex < this.props.sections.length - 1) {
-  //       sectionIndex = sectionIndex + 1;
-  //       rowBelow = 0;
-  //     } else {
-  //       rowBelow = row;
-  //     }
-  //   }
-  //   const nextIndexPath = {sectionIndex: sectionIndex, rowIndex: rowBelow};
-  //   this.setState(state => {
-  //     return {selectedRowIndexPath: nextIndexPath};
-  //   });
-  //   return nextIndexPath;
-  // };
+    if (rowBelow > count - 1) {
+      if (sectionIndex < this.props.sections.length - 1) {
+        sectionIndex = sectionIndex + 1;
+        rowBelow = 0;
+      } else {
+        rowBelow = row;
+      }
+    }
+    const nextIndexPath = {sectionIndex: sectionIndex, rowIndex: rowBelow};
+    this.setState(state => {
+      return {selectedRowIndexPath: nextIndexPath};
+    });
+    return nextIndexPath;
+  };
 
-  // _ensureItemAtIndexPathIsVisible = rowIndexPath => {
-  //   let index = rowIndexPath.rowIndex + 1;
-  //   for (let ii = 0; ii < rowIndexPath.sectionIndex; ii++) {
-  //     index += this.props.sections[ii].data.length + 2;
-  //   }
-  //   this._listRef.ensureItemAtIndexIsVisible(index);
-  // };
+  _ensureItemAtIndexPathIsVisible = rowIndexPath => {
+    if (this._listRef) {
+      let index = rowIndexPath.rowIndex + 1;
+      for (let ii = 0; ii < rowIndexPath.sectionIndex; ii++) {
+        index += this.props.sections[ii].data.length + 2;
+      }
+      this._listRef.ensureItemAtIndexIsVisible(index);
+    }
+  };
 
-  // _handleKeyDown = (e: ScrollEvent) => {
-  //   if (Platform.OS === 'macos') {
-  //     const event = e.nativeEvent;
-  //     const key = event.key;
-  //     let prevIndexPath = </typeof>this.state.selectedRowIndexPath;
-  //     let nextIndexPath = null;
-  //     const sectionIndex = </SectionT>this.state.selectedRowIndexPath.sectionIndex;
-  //     const rowIndex = </any>this.state.selectedRowIndexPath.rowIndex;
+  _handleKeyDown = (e: ScrollEvent) => {
+    if (Platform.OS === 'macos') {
+      const event = e.nativeEvent;
+      const key = event.key;
+      let prevIndexPath = this.state.selectedRowIndexPath;
+      let nextIndexPath = null;
+      const sectionIndex = this.state.selectedRowIndexPath.sectionIndex;
+      const rowIndex = this.state.selectedRowIndexPath.rowIndex;
 
-  //     if (key === 'DOWN_ARROW') {
-  //       nextIndexPath = this._selectRowBelowIndexPath(prevIndexPath);
-  //       this._ensureItemAtIndexPathIsVisible(nextIndexPath);
+      if (key === 'DOWN_ARROW') {
+        nextIndexPath = this._selectRowBelowIndexPath(prevIndexPath);
+        this._ensureItemAtIndexPathIsVisible(nextIndexPath);
 
-  //       if (this.props.onSelectionChanged) {
-  //         const item = this.props.sections[sectionIndex].data[rowIndex];
-  //         this.props.onSelectionChanged({
-  //           previousSelection: prevIndexPath,
-  //           newSelection: nextIndexPath,
-  //           item: item,
-  //         });
-  //       }
-  //     } else if (key === 'UP_ARROW') {
-  //       nextIndexPath = this._selectRowAboveIndexPath(prevIndexPath);
-  //       this._ensureItemAtIndexPathIsVisible(nextIndexPath);
+        if (this.props.onSelectionChanged) {
+          const item = this.props.sections[sectionIndex].data[rowIndex];
+          this.props.onSelectionChanged({
+            previousSelection: prevIndexPath,
+            newSelection: nextIndexPath,
+            item: item,
+          });
+        }
+      } else if (key === 'UP_ARROW') {
+        nextIndexPath = this._selectRowAboveIndexPath(prevIndexPath);
+        this._ensureItemAtIndexPathIsVisible(nextIndexPath);
 
-  //       if (this.props.onSelectionChanged) {
-  //         const item = this.props.sections[sectionIndex].data[rowIndex];
-  //         this.props.onSelectionChanged({
-  //           previousSelection: prevIndexPath,
-  //           newSelection: nextIndexPath,
-  //           item: item,
-  //         });
-  //       }
-  //     } else if (key === 'ENTER') {
-  //       if (this.props.onSelectionEntered) {
-  //         const item = this.props.sections[sectionIndex].data[rowIndex];
-  //         this.props.onSelectionEntered(item);
-  //       }
-  //     }
-  //   }
-  // }; // ]TODO(macOS GH#774)
+        if (this.props.onSelectionChanged) {
+          const item = this.props.sections[sectionIndex].data[rowIndex];
+          this.props.onSelectionChanged({
+            previousSelection: prevIndexPath,
+            newSelection: nextIndexPath,
+            item: item,
+          });
+        }
+      } else if (key === 'ENTER') {
+        if (this.props.onSelectionEntered) {
+          const item = this.props.sections[sectionIndex].data[rowIndex];
+          this.props.onSelectionEntered(item);
+        }
+      }
+    }
+  }; // ]TODO(macOS GH#774)
 
   _getItem(
     props: Props<SectionT>,
@@ -476,23 +477,22 @@ class VirtualizedSectionList<
     }
   };
 
-  // TODO(macOS add back selection support for 66 merge)
   // [TODO(macOS GH#774)
-  // _isItemSelected = (item: Item): boolean => {
-  //   let isSelected = false;
-  //   if (this.state.selectedRowIndexPath) {
-  //     const selection = this.state.selectedRowIndexPath;
-  //     const sections = this.props.sections;
-  //     if (sections && selection.sectionIndex < sections.length) {
-  //       const section = sections[selection.sectionIndex];
-  //       if (selection.rowIndex < section.data.length) {
-  //         const selectedItem = section.data[selection.rowIndex];
-  //         isSelected = item === selectedItem;
-  //       }
-  //     }
-  //   }
-  // return isSelected;
-  // };
+  _isItemSelected = (item: Item): boolean => {
+    let isSelected = false;
+    if (this.state.selectedRowIndexPath) {
+      const selection = this.state.selectedRowIndexPath;
+      const sections = this.props.sections;
+      if (sections && selection.sectionIndex < sections.length) {
+        const section = sections[selection.sectionIndex];
+        if (selection.rowIndex < section.data.length) {
+          const selectedItem = section.data[selection.rowIndex];
+          isSelected = item === selectedItem;
+        }
+      }
+    }
+    return isSelected;
+  };
   // ]TODO(macOS GH#774)
 
   _renderItem = (listItemCount: number) => ({
@@ -533,7 +533,7 @@ class VirtualizedSectionList<
           }
           cellKey={info.key}
           index={infoIndex}
-          // isSelected={this._isItemSelected(item)} // TODO(macOS GH#774) // TODO(macOS add back selection support for 66 merge)
+          isSelected={this._isItemSelected(item)} // TODO(macOS GH#774)
           item={item}
           leadingItem={info.leadingItem}
           leadingSection={info.leadingSection}
@@ -631,7 +631,7 @@ type ItemWithSeparatorProps = $ReadOnly<{|
   cellKey: string,
   index: number,
   item: Item,
-  // isSelected: boolean, // TODO(macOS GH#774) // TODO(macOS add back selection support for 66 merge)
+  isSelected: boolean, // TODO(macOS GH#774)
   setSelfHighlightCallback: (
     cellKey: string,
     updateFn: ?(boolean) => void,
@@ -659,6 +659,7 @@ function ItemWithSeparator(props: ItemWithSeparatorProps): React.Node {
     setSelfUpdatePropsCallback,
     updatePropsFor,
     item,
+    isSelected, // TODO(macOS GH#774)
     index,
     section,
     inverted,
@@ -735,7 +736,7 @@ function ItemWithSeparator(props: ItemWithSeparatorProps): React.Node {
   const element = props.renderItem({
     item,
     index,
-    // isSelected, // TODO(macOS GH#774) // TODO(macOS add back selection support for 66 merge)
+    isSelected, // TODO(macOS GH#774)
     section,
     separators,
   });

--- a/Libraries/Utilities/Platform.macos.js
+++ b/Libraries/Utilities/Platform.macos.js
@@ -58,10 +58,13 @@ const Platform = {
   },
   select: <D, N, I>(spec: PlatformSelectSpec<D, N, I>): D | N | I =>
     'macos' in spec
-      ? spec.macos
+      ? // $FlowFixMe[incompatible-return]
+        spec.macos
       : 'native' in spec
-      ? spec.native
-      : spec.default,
+      ? // $FlowFixMe[incompatible-return]
+        spec.native
+      : // $FlowFixMe[incompatible-return]
+        spec.default,
 };
 
 module.exports = Platform;

--- a/packages/rn-tester/js/RNTesterApp.ios.js
+++ b/packages/rn-tester/js/RNTesterApp.ios.js
@@ -75,8 +75,8 @@ RNTesterList.Components.concat(RNTesterList.APIs).forEach(
 // [TODO(OSS Candidate ISS#2710739)
 class EnumerateExamplePages extends React.Component<{}> {
   render() {
-    RNTesterList.ComponentExamples.concat(RNTesterList.APIExamples).forEach(
-      (Example: RNTesterExample) => {
+    RNTesterList.Components.concat(RNTesterList.APIs).forEach(
+      (Example: RNTesterModuleInfo) => {
         let skipTest = false;
         if ('skipTest' in Example) {
           const platforms = Example.skipTest;

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
@@ -961,9 +961,16 @@ class EnabledExamples extends React.Component<{}> {
   }
 }
 // [TODO(OSS Candidate ISS#2710739)
-class DisplayOptionsStatusExample extends React.Component<{}> {
-  state = {};
-
+type DisplayOptionsStatusExampleState = {
+  highContrastEnabled: boolean,
+  invertColorsEnabled: boolean,
+  reduceMotionEnabled: boolean,
+  reduceTransparencyEnabled: boolean,
+};
+class DisplayOptionsStatusExample extends React.Component<
+  {},
+  DisplayOptionsStatusExampleState,
+> {
   componentDidMount() {
     AccessibilityInfo.addEventListener(
       'highContrastChanged',
@@ -1049,7 +1056,7 @@ class DisplayOptionsStatusExample extends React.Component<{}> {
     });
   };
 
-  render() {
+  render(): React.Node {
     return (
       <View>
         <View>
@@ -1141,26 +1148,6 @@ class EnabledExample extends React.Component<
           title={this.state.isEnabled ? 'disable' : 'enable'}
           onPress={this._handleToggled}
         />
-      </View>
-    );
-  }
-}
-
-class SetAccessibilityFocus extends React.Component<{}> {
-  _handleOnPress = () => {
-    if (findNodeHandle(this.focusRef.current)) {
-      const reactTag = findNodeHandle(this.focusRef.current);
-      AccessibilityInfo.setAccessibilityFocus(reactTag);
-    }
-  };
-  render() {
-    this.focusRef = React.createRef();
-    return (
-      <View>
-        <Button onPress={this._handleOnPress} title="Set Accessibility Focus" />
-        <Text ref={this.focusRef} accessible={true}>
-          Move focus here on button press.
-        </Text>
       </View>
     );
   }

--- a/packages/rn-tester/js/examples/Alert/AlertMacOSExample.js
+++ b/packages/rn-tester/js/examples/Alert/AlertMacOSExample.js
@@ -16,7 +16,7 @@ const {StyleSheet, View, Text, TouchableHighlight, AlertMacOS} = ReactNative;
 
 const {examples: SharedAlertExamples} = require('./AlertExample');
 
-import type {RNTesterExampleModuleItem} from '../../types/RNTesterTypes';
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 exports.framework = 'React';
 exports.title = 'AlertMacOS';
@@ -149,7 +149,7 @@ exports.examples = ([
       );
     },
   },
-]: RNTesterExampleModuleItem[]);
+]: RNTesterModuleExample[]);
 
 class PromptOptions extends React.Component<$FlowFixMeProps, any> {
   state: any;
@@ -188,7 +188,9 @@ class PromptOptions extends React.Component<$FlowFixMeProps, any> {
         <TouchableHighlight
           style={styles.wrapper}
           onPress={() =>
-            AlertMacOS.prompt('Type a value', null, this.saveResponse)
+            AlertMacOS.prompt('Type a value', null, value =>
+              this.saveResponse(value),
+            )
           }>
           <View style={styles.button}>
             <Text>prompt with title & callback</Text>
@@ -211,7 +213,7 @@ class PromptOptions extends React.Component<$FlowFixMeProps, any> {
             AlertMacOS.prompt(
               'Type a value',
               null,
-              this.saveResponse,
+              value => this.saveResponse(value),
               undefined,
               [{default: 'Default value', placeholder: ''}],
             )

--- a/packages/rn-tester/js/types/RNTesterTypes.js
+++ b/packages/rn-tester/js/types/RNTesterTypes.js
@@ -10,10 +10,14 @@
 
 import * as React from 'react';
 
+// TODO(macOS GH#774) - useful since RNTesterModuleExample.platform can either be
+// one of these strings or an array of said strings
+type RNTesterPlatform = 'ios' | 'android' | 'macos';
+
 export type RNTesterModuleExample = $ReadOnly<{|
   name?: string,
   title: string,
-  platform?: 'ios' | 'android' | 'macos', // TODO(OSS Candidate ISS#2710739)
+  platform?: RNTesterPlatform | Array<RNTesterPlatform>, // TODO(OSS Candidate ISS#2710739)
   description?: string,
   expect?: string,
   render: () => React.Node,


### PR DESCRIPTION
Apply a number of fixes such that `yarn flow-check-ios`, `yarn flow-check-android`, and `yarn flow-check-macos` come back clean.

Most of these changes are just bits of refactoring, but one notable thing is that we're bringing back selection support (which was originally removed with 3cb82fef3ee03ff87986662a7822ba68a6222d24). We'll need to do this anyway, so we might as well do it now.