### PR TITLE
Get RNTester compiling for macOS

### DIFF
--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
@@ -7,9 +7,7 @@
 
 #import <React/RCTPushNotificationManager.h>
 
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
 #import <UserNotifications/UserNotifications.h>
-#endif // TODO(macOS GH#774)
 
 #import <FBReactNativeSpec/FBReactNativeSpec.h>
 #import <React/RCTBridge.h>

--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -505,6 +505,7 @@ static RCTUIColor *defaultPlaceholderColor() // TODO(OSS Candidate ISS#2710739)
 }
 
 #pragma mark - Caret Manipulation
+#if !TARGET_OS_OSX // TODO(macOS GH#774)
 
 - (CGRect)caretRectForPosition:(UITextPosition *)position
 {
@@ -514,6 +515,7 @@ static RCTUIColor *defaultPlaceholderColor() // TODO(OSS Candidate ISS#2710739)
 
   return [super caretRectForPosition:position];
 }
+#endif
 
 #pragma mark - Utility Methods
 

--- a/React/Base/RCTBridgeModule.h
+++ b/React/Base/RCTBridgeModule.h
@@ -6,7 +6,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTDefines.h>
 
@@ -444,7 +444,7 @@ typedef NSURL * (^RCTBridgelessBundleURLGetter)(void);
 @property NSURL *bundleURL;
 @end
 
-typedef UIView * (^RCTBridgelessComponentViewProvider)(NSNumber *);
+typedef RCTPlatformView * (^RCTBridgelessComponentViewProvider)(NSNumber *); // TODO(macOS GH#774)
 
 /**
  * A class that allows NativeModules to query for views, given React Tags.
@@ -453,7 +453,7 @@ typedef UIView * (^RCTBridgelessComponentViewProvider)(NSNumber *);
 - (void)setBridge:(RCTBridge *)bridge;
 - (void)setBridgelessComponentViewProvider:(RCTBridgelessComponentViewProvider)bridgelessComponentViewProvider;
 
-- (UIView *)viewForReactTag:(NSNumber *)reactTag;
+- (RCTPlatformView *)viewForReactTag:(NSNumber *)reactTag; // TODO(macOS GH#774)
 @end
 
 typedef void (^RCTBridgelessJSModuleMethodInvoker)(

--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -1000,7 +1000,7 @@ static NSColor *RCTColorWithSystemEffect(NSColor* color, NSString *systemEffectS
     if ((value = [dictionary objectForKey:@"semantic"])) {
       if ([value isKindOfClass:[NSString class]]) {
         NSString *semanticName = value;
-        RCTUIColor *color = [UIColor colorNamed:semanticName]; // TODO(macOS GH#750)
+        RCTUIColor *color = [RCTUIColor colorNamed:semanticName]; // TODO(macOS GH#750)
         if (color != nil) {
           return color;
         }
@@ -1013,7 +1013,7 @@ static NSColor *RCTColorWithSystemEffect(NSColor* color, NSString *systemEffectS
         return color;
       } else if ([value isKindOfClass:[NSArray class]]) {
         for (id name in value) {
-          RCTUIColor *color = [UIColor colorNamed:name]; // TODO(macOS GH#750)
+          RCTUIColor *color = [RCTUIColor colorNamed:name]; // TODO(macOS GH#750)
           if (color != nil) {
             return color;
           }

--- a/React/Base/RCTUIKit.h
+++ b/React/Base/RCTUIKit.h
@@ -63,6 +63,8 @@ UIKIT_STATIC_INLINE CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *path)
 #define RCTUIView UIView // TODO(macOS ISS#3536887)
 #define RCTUIScrollView UIScrollView // TODO(macOS ISS#3536887)
 
+#define RCTPlatformWindow UIWindow
+
 UIKIT_STATIC_INLINE RCTPlatformView *RCTUIViewHitTestWithEvent(RCTPlatformView *view, CGPoint point, UIEvent *event)
 {
   return [view hitTest:point withEvent:event];
@@ -360,6 +362,8 @@ CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *path);
 
 // UIView
 #define RCTPlatformView NSView
+
+#define RCTPlatformWindow NSWindow
 
 @interface RCTUIView : NSView // TODO(macOS ISS#3536887)
 

--- a/React/Base/RCTViewRegistry.m
+++ b/React/Base/RCTViewRegistry.m
@@ -26,9 +26,9 @@
   _bridgelessComponentViewProvider = bridgelessComponentViewProvider;
 }
 
-- (UIView *)viewForReactTag:(NSNumber *)reactTag
+- (RCTPlatformView *)viewForReactTag:(NSNumber *)reactTag // TODO(macOS GH#774)
 {
-  UIView *view = nil;
+  RCTPlatformView *view = nil; // TODO(macOS GH#774)
 
   RCTBridge *bridge = _bridge;
   if (bridge) {

--- a/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.mm
+++ b/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.mm
@@ -62,7 +62,7 @@ RCT_NOT_IMPLEMENTED(-(nullable instancetype)initWithCoder : (NSCoder *)coder)
     [self _updateViews];
 
     // For backward compatibility with RCTRootView, set a color here instead of transparent (OS default).
-    self.backgroundColor = [UIColor whiteColor];
+    self.backgroundColor = [RCTUIColor whiteColor];
   }
 
   return self;

--- a/React/CoreModules/RCTAlertController.h
+++ b/React/CoreModules/RCTAlertController.h
@@ -15,7 +15,7 @@
 
 #if !TARGET_OS_OSX // [TODO(macOS GH#774)
 - (void)show:(BOOL)animated completion:(void (^)(void))completion;
-#endif // ]TODO(macOS GH#774)
 - (void)hide;
+#endif // ]TODO(macOS GH#774)
 
 @end

--- a/React/CoreModules/RCTAlertController.m
+++ b/React/CoreModules/RCTAlertController.m
@@ -35,11 +35,11 @@
   [self.alertWindow makeKeyAndVisible];
   [self.alertWindow.rootViewController presentViewController:self animated:animated completion:completion];
 }
-#endif // ]TODO(macOS GH#774)
 
 - (void)hide
 {
   _alertWindow = nil;
 }
+#endif // ]TODO(macOS GH#774)
 
 @end

--- a/React/CoreModules/RCTDevMenu.mm
+++ b/React/CoreModules/RCTDevMenu.mm
@@ -190,7 +190,7 @@ RCT_EXPORT_MODULE()
 - (void)showOnShake
 {
   if ([((RCTDevSettings *)[_moduleRegistry moduleForName:"DevSettings"]) isShakeToShowDevMenuEnabled]) {
-    for (UIWindow *window in [RCTSharedApplication() windows]) {
+    for (RCTPlatformWindow *window in [RCTSharedApplication() windows]) {
       NSString *recursiveDescription = [window valueForKey:@"recursiveDescription"];
       if ([recursiveDescription containsString:@"RCTView"]) {
         [self show];

--- a/React/CoreModules/RCTDeviceInfo.mm
+++ b/React/CoreModules/RCTDeviceInfo.mm
@@ -173,11 +173,11 @@ NSDictionary *RCTExportedDimensions(RCTPlatformView *rootView)
   // Report the event across the bridge.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
     [[moduleRegistry moduleForName:"EventDispatcher"] sendDeviceEventWithName:@"didUpdateDimensions"
+#if !TARGET_OS_OSX // TODO(macOS GH#774)
                                                                          body:RCTExportedDimensions(moduleRegistry)];
 #else // [TODO(macOS GH#774)
-    [bridge.eventDispatcher sendDeviceEventWithName:@"didUpdateDimensions" body:RCTExportedDimensions(nil)];
+                                                                         body:RCTExportedDimensions(nil)];
 #endif // ]TODO(macOS GH#774)
 #pragma clang diagnostic pop
   });

--- a/React/Views/RCTView.h
+++ b/React/Views/RCTView.h
@@ -95,13 +95,13 @@ extern const UIAccessibilityTraits SwitchAccessibilityTrait;
 /**
  * Border colors (actually retained).
  */
-@property (nonatomic, strong) UIColor *borderTopColor;
-@property (nonatomic, strong) UIColor *borderRightColor;
-@property (nonatomic, strong) UIColor *borderBottomColor;
-@property (nonatomic, strong) UIColor *borderLeftColor;
-@property (nonatomic, strong) UIColor *borderStartColor;
-@property (nonatomic, strong) UIColor *borderEndColor;
-@property (nonatomic, strong) UIColor *borderColor;
+@property (nonatomic, strong) RCTUIColor *borderTopColor;
+@property (nonatomic, strong) RCTUIColor *borderRightColor;
+@property (nonatomic, strong) RCTUIColor *borderBottomColor;
+@property (nonatomic, strong) RCTUIColor *borderLeftColor;
+@property (nonatomic, strong) RCTUIColor *borderStartColor;
+@property (nonatomic, strong) RCTUIColor *borderEndColor;
+@property (nonatomic, strong) RCTUIColor *borderColor;
 
 /**
  * Border widths.

--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -542,7 +542,6 @@ static inline void RCTApplyTransformationAccordingLayoutDirection(
   [super removeReactSubview:subview];
 #if TARGET_OS_OSX // [TODO(macOS GH#774)
   _scrollView.documentView = nil;
-  _contentSize = CGSizeZero;
 #else // ]TODO(macOS GH#774)
   if ([subview conformsToProtocol:@protocol(RCTCustomRefreshContolProtocol)]) {
     [_scrollView setCustomRefreshControl:nil];

--- a/ReactTurboModuleCxx/React-TurboModuleCxx-RNW.podspec
+++ b/ReactTurboModuleCxx/React-TurboModuleCxx-RNW.podspec
@@ -4,7 +4,7 @@ package = JSON.parse(File.read(File.join(__dir__, "..", "package.json")))
 version = package['version']
 
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
-folly_version = '2020.01.13.00'
+folly_version = '2021.06.28.00-v2'
 
 Pod::Spec.new do |s|
   s.name                   = "React-TurboModuleCxx-RNW"

--- a/ReactTurboModuleCxx/React-TurboModuleCxx-WinRTPort.podspec
+++ b/ReactTurboModuleCxx/React-TurboModuleCxx-WinRTPort.podspec
@@ -4,7 +4,7 @@ package = JSON.parse(File.read(File.join(__dir__, "..", "package.json")))
 version = package['version']
 
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
-folly_version = '2020.01.13.00'
+folly_version = '2021.06.28.00-v2'
 
 source = { :git => 'https://github.com/microsoft/react-native-macos.git' }
 if version == '1000.0.0'

--- a/packages/rn-tester/Podfile
+++ b/packages/rn-tester/Podfile
@@ -31,8 +31,8 @@ def pods(options = {})
   # Additional Pods which aren't included in the default Podfile
   pod 'React-RCTPushNotification', :path => "#{prefix_path}/Libraries/PushNotificationIOS"
   pod 'Yoga', :path => "#{prefix_path}/ReactCommon/yoga", :modular_headers => true
-  # pod 'React-TurboModuleCxx-WinRTPort', :path => "#{prefix_path}/ReactTurboModuleCxx" # TODO(macOS GH#774)
-  # pod 'React-TurboModuleCxx-RNW', :podspec => "#{prefix_path}/ReactTurboModuleCxx/React-TurboModuleCxx-RNW.podspec" # TODO(macOS GH#774)
+  pod 'React-TurboModuleCxx-WinRTPort', :path => "#{prefix_path}/ReactTurboModuleCxx" # TODO(macOS GH#774)
+  pod 'React-TurboModuleCxx-RNW', :podspec => "#{prefix_path}/ReactTurboModuleCxx/React-TurboModuleCxx-RNW.podspec" # TODO(macOS GH#774)
   # Additional Pods which are classed as unstable
 end
 

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -349,6 +349,19 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-runtimeexecutor (1000.0.0):
     - React-jsi (= 1000.0.0)
+  - React-TurboModuleCxx-RNW (1000.0.0):
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-callinvoker (= 1000.0.0)
+    - React-TurboModuleCxx-WinRTPort (= 1000.0.0)
+    - ReactCommon/turbomodule/core (= 1000.0.0)
+  - React-TurboModuleCxx-WinRTPort (1000.0.0):
+    - React-TurboModuleCxx-WinRTPort/Shared (= 1000.0.0)
+    - React-TurboModuleCxx-WinRTPort/WinRT (= 1000.0.0)
+  - React-TurboModuleCxx-WinRTPort/Shared (1000.0.0)
+  - React-TurboModuleCxx-WinRTPort/WinRT (1000.0.0):
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-callinvoker (= 1000.0.0)
+    - React-TurboModuleCxx-WinRTPort/Shared (= 1000.0.0)
   - ReactCommon/turbomodule/core (1000.0.0):
     - DoubleConversion
     - glog
@@ -429,6 +442,8 @@ DEPENDENCIES:
   - React-RCTText (from `../../Libraries/Text`)
   - React-RCTVibration (from `../../Libraries/Vibration`)
   - React-runtimeexecutor (from `../../ReactCommon/runtimeexecutor`)
+  - React-TurboModuleCxx-RNW (from `../../ReactTurboModuleCxx/React-TurboModuleCxx-RNW.podspec`)
+  - React-TurboModuleCxx-WinRTPort (from `../../ReactTurboModuleCxx`)
   - ReactCommon/turbomodule/core (from `../../ReactCommon`)
   - ReactCommon/turbomodule/samples (from `../../ReactCommon`)
   - Yoga (from `../../ReactCommon/yoga`)
@@ -513,6 +528,10 @@ EXTERNAL SOURCES:
     :path: "../../Libraries/Vibration"
   React-runtimeexecutor:
     :path: "../../ReactCommon/runtimeexecutor"
+  React-TurboModuleCxx-RNW:
+    :podspec: "../../ReactTurboModuleCxx/React-TurboModuleCxx-RNW.podspec"
+  React-TurboModuleCxx-WinRTPort:
+    :path: "../../ReactTurboModuleCxx"
   ReactCommon:
     :path: "../../ReactCommon"
   Yoga:
@@ -523,8 +542,8 @@ SPEC CHECKSUMS:
   boost-for-react-native: d5ad1140010aa8cb622323a781ecbeab4425d19a
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 8dfb8e6a364e688caa15f66896caee7845035144
-  FBLazyVector: 8676ba4dbede2c049ffe806f147cac0d9ba6638f
-  FBReactNativeSpec: 83f7cb5c8d3d2b0b732ddaaab2abc39376cd2617
+  FBLazyVector: 21e4a6a72ca9555ce887f58c5cfdd10eb79746ac
+  FBReactNativeSpec: 517682491abcd1ea6e5c8ceaf3fc4ed2c5f08bf3
   Flipper: 30e8eeeed6abdc98edaf32af0cda2f198be4b733
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 57ffbe81ef95306cc9e69c4aa3aeeeeb58a6a28c
@@ -539,34 +558,36 @@ SPEC CHECKSUMS:
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   RCT-Folly: 1870fc2f6c34038cae3556a1af98f979f2ce63d9
-  RCTRequired: acb3b662f1ae34914ed1ab9245f62abcc7a259cb
-  RCTTypeSafety: b40b772c795a60ad1e90459edf712e9efba74a4e
-  React: 50efdd6443be480ea997e368e3e994e9d51854c5
-  React-callinvoker: fa40e2857537d112560a828e35a79bcd6c65b855
-  React-Core: 1a2db3037385fec951b95b0bb6b1395ecd6f8f3d
-  React-CoreModules: 8d6b4ff95347e178e10514779637599bed1ed24e
-  React-cxxreact: 10830ed5e0745f38b6bbd8086fa435cd0f366c6d
-  React-jsi: c3927aec1af28ee003fdf847b7aa536320737c7a
-  React-jsiexecutor: 046cc11dc4cb2db78ec9db624112eda5bf8a5949
-  React-jsinspector: 96e97a435686e0fc6c1385a19ce7f4841e52fd23
-  React-logger: 82ecb58cc9b1af9c009c76e9b9d5549f17d0caf0
-  React-perflogger: ab8fb59489d1aa298bda2bfa5bc0e3be426f244b
-  React-RCTActionSheet: 8c050d6ace4545459f1e7e259b128eb384e4d97d
-  React-RCTAnimation: 076ab34c81fe58e2fe5f9a0a2ebd1374bcf5e6cb
-  React-RCTBlob: 5a8624d541a3169b6d41afa628f13e8eaeb4c546
-  React-RCTImage: de33a348f2bce33725ecd1a385398c8b6faec7c1
-  React-RCTLinking: cbd754b28810522b61b2c4b1d5c327c991b4c25b
-  React-RCTNetwork: ede6cf7e876543be21274f70579df1daf3acb290
-  React-RCTPushNotification: 7af46064c3092b73f479d2c7b95eea56fb451329
-  React-RCTSettings: 945c5ba4382a7602b7a9efa8607384220dbf6238
-  React-RCTTest: ce52cf6bc07230508b45cdb6a9a1f606240da574
-  React-RCTText: 83a3aea8b91e810899a26169a8f10141009964d9
-  React-RCTVibration: efaaa7c3300632f9102632a4dfab1306c86131da
-  React-runtimeexecutor: b557467332c37253d76d54f786db115a069e3418
-  ReactCommon: dcb97177023177bca5b1547f23dda4c3902f1ecc
-  Yoga: 8b76e4b2964a200ffcc9342a95a6b209b3b4abeb
+  RCTRequired: 53a6fa1ffdc8733e433327d43ef50d78a69875ea
+  RCTTypeSafety: 980bdbd90ce0c09b22ee97a659ff28fd6af48763
+  React: 9f03c86dc38fdcd66014d0080840ca4f80521ce3
+  React-callinvoker: 35cb6581f382eb9e7fd817eeeba3cec9dab84315
+  React-Core: 98df395387cf9011e32f5ce1d549ad50448555c6
+  React-CoreModules: 1662743d62bcdc926aaa5f10dcc9d474f1d3cfa4
+  React-cxxreact: 5e72ccec96141c2f0bce5f4ba312b34dcb966ed2
+  React-jsi: 26e743c382003312ebdc21b6fbdae0be97ff7731
+  React-jsiexecutor: d040a800aa6ce1b9dde61d26ac808c49161f197f
+  React-jsinspector: 5481c24be81e17fa4607c00202fccacaabae9c54
+  React-logger: 40e0aeda2d4d6ccc0da8a415298dc00f7dbec93d
+  React-perflogger: ac7664535b4304a42f8da437f22cce4b9a369ea8
+  React-RCTActionSheet: ca861c238e9b2c283b6930ab0d95c190f36dd626
+  React-RCTAnimation: 3d23a42171628bbe0258757c7f31dcb7bccea0e2
+  React-RCTBlob: f2e3319496e3aa490df5d1057d6a7fb85ae6a658
+  React-RCTImage: 3540d63598ad941a87e39ac365d308ddf6a0a803
+  React-RCTLinking: 6c7abae0e917208c77319aefb7e181e949ec98f1
+  React-RCTNetwork: 24d761c1d4ee3a90bcb6665e4afb975a95f90b9c
+  React-RCTPushNotification: 90a8ceb22192c6cab33b7eaab357398259e9a76f
+  React-RCTSettings: 36b2f08525677926c766bdb01a9cf013575e3d51
+  React-RCTTest: 58249e1eb508630e6d362aaf2c277de3eeea76bf
+  React-RCTText: 6d15be1b8187a69f5e941f16916bfa7826a70ca0
+  React-RCTVibration: 9b1e137a1d8c51bee2c8126d729bd1cbacbc3f8e
+  React-runtimeexecutor: 07efa5a070d74337d48f5754a34832c6d08b861e
+  React-TurboModuleCxx-RNW: 84be9c2264b05327ba1133dcf1c8e67a4c238a57
+  React-TurboModuleCxx-WinRTPort: d39d54859c31b437240b94b67308322c413c7495
+  ReactCommon: 6235b1bbe7b960eb8e9ce3a1367b4103cada1acc
+  Yoga: d9ee6dd4731d72fdd16a8463cec56610f75e627e
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 996bfa282f5ca1900414c0e267589e9cbefbe3c4
+PODFILE CHECKSUM: d8714a4573a1359d5bff89b4221daaba80d2652c
 
-COCOAPODS: 1.10.2
+COCOAPODS: 1.11.2

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -542,8 +542,8 @@ SPEC CHECKSUMS:
   boost-for-react-native: d5ad1140010aa8cb622323a781ecbeab4425d19a
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 8dfb8e6a364e688caa15f66896caee7845035144
-  FBLazyVector: 21e4a6a72ca9555ce887f58c5cfdd10eb79746ac
-  FBReactNativeSpec: 517682491abcd1ea6e5c8ceaf3fc4ed2c5f08bf3
+  FBLazyVector: 187bf8acbd55cfe4d402068907de2c5359a33085
+  FBReactNativeSpec: 465aecd88b1e5117eec7194d1f5ccf6b2ae3a364
   Flipper: 30e8eeeed6abdc98edaf32af0cda2f198be4b733
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 57ffbe81ef95306cc9e69c4aa3aeeeeb58a6a28c
@@ -558,34 +558,34 @@ SPEC CHECKSUMS:
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   RCT-Folly: 1870fc2f6c34038cae3556a1af98f979f2ce63d9
-  RCTRequired: 53a6fa1ffdc8733e433327d43ef50d78a69875ea
-  RCTTypeSafety: 980bdbd90ce0c09b22ee97a659ff28fd6af48763
-  React: 9f03c86dc38fdcd66014d0080840ca4f80521ce3
-  React-callinvoker: 35cb6581f382eb9e7fd817eeeba3cec9dab84315
-  React-Core: 98df395387cf9011e32f5ce1d549ad50448555c6
-  React-CoreModules: 1662743d62bcdc926aaa5f10dcc9d474f1d3cfa4
-  React-cxxreact: 5e72ccec96141c2f0bce5f4ba312b34dcb966ed2
-  React-jsi: 26e743c382003312ebdc21b6fbdae0be97ff7731
-  React-jsiexecutor: d040a800aa6ce1b9dde61d26ac808c49161f197f
-  React-jsinspector: 5481c24be81e17fa4607c00202fccacaabae9c54
-  React-logger: 40e0aeda2d4d6ccc0da8a415298dc00f7dbec93d
-  React-perflogger: ac7664535b4304a42f8da437f22cce4b9a369ea8
-  React-RCTActionSheet: ca861c238e9b2c283b6930ab0d95c190f36dd626
-  React-RCTAnimation: 3d23a42171628bbe0258757c7f31dcb7bccea0e2
-  React-RCTBlob: f2e3319496e3aa490df5d1057d6a7fb85ae6a658
-  React-RCTImage: 3540d63598ad941a87e39ac365d308ddf6a0a803
-  React-RCTLinking: 6c7abae0e917208c77319aefb7e181e949ec98f1
-  React-RCTNetwork: 24d761c1d4ee3a90bcb6665e4afb975a95f90b9c
-  React-RCTPushNotification: 90a8ceb22192c6cab33b7eaab357398259e9a76f
-  React-RCTSettings: 36b2f08525677926c766bdb01a9cf013575e3d51
-  React-RCTTest: 58249e1eb508630e6d362aaf2c277de3eeea76bf
-  React-RCTText: 6d15be1b8187a69f5e941f16916bfa7826a70ca0
-  React-RCTVibration: 9b1e137a1d8c51bee2c8126d729bd1cbacbc3f8e
-  React-runtimeexecutor: 07efa5a070d74337d48f5754a34832c6d08b861e
+  RCTRequired: caa65fbd1ec96dcdeaf44ff3223701af930a9e88
+  RCTTypeSafety: 80bf80c62bacdf955bac75cf0e56440aaf29bfeb
+  React: cf735a1d5323c38c19bdd8c906cbe1f3eb801265
+  React-callinvoker: aa2a8f688276d994382300ea8a79b64eb0a1384b
+  React-Core: 2e7b5f3528f41ab6b0845aa45994c3ddf6671d55
+  React-CoreModules: cee02273151cc75f7b56dcfd5ae62cce7b37292f
+  React-cxxreact: db4d569a160b07eb4e749f0ec76f9a9a77160f5e
+  React-jsi: 3154732689c09d51bdacfa20b791238dcc9370cb
+  React-jsiexecutor: 965373b791a22096a3b95e691d325a7fca033228
+  React-jsinspector: 9ff76bf9885b70dd37e6a6b88031e32fb8289c46
+  React-logger: 5e27139944f0b9c41cbf7ee09f9d3dce944123c7
+  React-perflogger: 0be7d39bd1622fcdecaa4b0411c5fb289011cbb1
+  React-RCTActionSheet: 34f9abd13f26fc1e0428733249119939a85f82de
+  React-RCTAnimation: a93cf10daeef41d6eb9cefb24c0f4d44f0566fc9
+  React-RCTBlob: 26aa95e2d86b4ec5a9a12557f88fd76a9d153681
+  React-RCTImage: 2f0983b329ed3b39c683185c42afb39bb7a024da
+  React-RCTLinking: 04750b3852d32bddf28cb0df216e6f6e8a34d1ad
+  React-RCTNetwork: 0665601c8d4ce1e565a3408dcb4fb5ae07653f4f
+  React-RCTPushNotification: 4217a09f9f050dd2576d656bacd967937c92d3d9
+  React-RCTSettings: 8ae9f10375c41008b7f07972f0e792fab604f83b
+  React-RCTTest: 714b1715ff2273ff5d14f66a031f752aac3bbf48
+  React-RCTText: fa790c643b00bb1a19c1187491337a5700306753
+  React-RCTVibration: 10f8abade8d20fe9c0fefc9533bb5e9acc9f9af0
+  React-runtimeexecutor: dbe57c917a0dffe48cf2e4f87575bce64ccfea98
   React-TurboModuleCxx-RNW: 84be9c2264b05327ba1133dcf1c8e67a4c238a57
-  React-TurboModuleCxx-WinRTPort: d39d54859c31b437240b94b67308322c413c7495
-  ReactCommon: 6235b1bbe7b960eb8e9ce3a1367b4103cada1acc
-  Yoga: d9ee6dd4731d72fdd16a8463cec56610f75e627e
+  React-TurboModuleCxx-WinRTPort: ef2b75da81e8206a130edc5d5ab6d1f2ac07ade0
+  ReactCommon: 2a7af4e5b8af603f48db222a1f4dfcfe43565db9
+  Yoga: 32f441f48ee15309b355d44cc510b850b2e70fcc
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: d8714a4573a1359d5bff89b4221daaba80d2652c

--- a/packages/rn-tester/RNTester-macOS/AppDelegate.mm
+++ b/packages/rn-tester/RNTester-macOS/AppDelegate.mm
@@ -153,13 +153,13 @@ NSString *kBundleNameJS = @"RNTesterApp";
 - (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass
 {
   if (moduleClass == RCTImageLoader.class) {
-    return [[moduleClass alloc] initWithRedirectDelegate:nil loadersProvider:^NSArray<id<RCTImageURLLoader>> *{
+    return [[moduleClass alloc] initWithRedirectDelegate:nil loadersProvider:^NSArray<id<RCTImageURLLoader>> *(__unused RCTModuleRegistry * moduleRegistry) {
       return @[[RCTLocalAssetImageLoader new]];
-    } decodersProvider:^NSArray<id<RCTImageDataDecoder>> *{
+    } decodersProvider:^NSArray<id<RCTImageDataDecoder>> *(__unused RCTModuleRegistry * moduleRegistry) {
       return @[[RCTGIFImageDecoder new]];
     }];
   } else if (moduleClass == RCTNetworking.class) {
-    return [[moduleClass alloc] initWithHandlersProvider:^NSArray<id<RCTURLRequestHandler>> *{
+    return [[moduleClass alloc] initWithHandlersProvider:^NSArray<id<RCTURLRequestHandler>> *(__unused RCTModuleRegistry * moduleRegistry) {
       return @[
         [RCTHTTPRequestHandler new],
         [RCTDataRequestHandler new],

--- a/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
+++ b/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
@@ -7,14 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		087CFC06CF5A5AA9DBB32BE2 /* libPods-RNTesterUnitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AB0102C840930F7AC64C3D36 /* libPods-RNTesterUnitTests.a */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		272E6B3F1BEA849E001FCF37 /* UpdatePropertiesExampleView.m in Sources */ = {isa = PBXBuildFile; fileRef = 272E6B3C1BEA849E001FCF37 /* UpdatePropertiesExampleView.m */; };
 		27F441EC1BEBE5030039B79C /* FlexibleSizeExampleView.m in Sources */ = {isa = PBXBuildFile; fileRef = 27F441E81BEBE5030039B79C /* FlexibleSizeExampleView.m */; };
-		28A91DB1D5B44426DC1C8516 /* libPods-RNTester-macOSUnitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7DBA22D1B717C9D2E9B00E92 /* libPods-RNTester-macOSUnitTests.a */; };
 		2DDEF0101F84BF7B00DBDF73 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2DDEF00F1F84BF7B00DBDF73 /* Images.xcassets */; };
 		3811324724550A8F009E988D /* RNTesterUnitTestsBundle.js in Resources */ = {isa = PBXBuildFile; fileRef = E7DB20B322B2BAA4005AC45F /* RNTesterUnitTestsBundle.js */; };
 		383838BD244BC2FF005FAC75 /* RCTComponentPropsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7DB20CC22B2BAA5005AC45F /* RCTComponentPropsTests.m */; };
-		383838C0244BC3BD005FAC75 /* libPods-RNTesterUnitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 383838BF244BC3AE005FAC75 /* libPods-RNTesterUnitTests.a */; };
 		383838C1244BC3D9005FAC75 /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E7DB213022B2C649005AC45F /* JavaScriptCore.framework */; };
 		383838C2244BC52B005FAC75 /* RCTAllocationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7DB20C622B2BAA5005AC45F /* RCTAllocationTests.m */; };
 		383838C3244BC52E005FAC75 /* RCTAnimationUtilsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7DB20B222B2BAA4005AC45F /* RCTAnimationUtilsTests.m */; };
@@ -57,24 +56,25 @@
 		38C8AC1F246611E500BA7FAA /* RNTesterLoadAllPages.m in Sources */ = {isa = PBXBuildFile; fileRef = 38C8AC1E246611E500BA7FAA /* RNTesterLoadAllPages.m */; };
 		38C8AC20246611E500BA7FAA /* RNTesterLoadAllPages.m in Sources */ = {isa = PBXBuildFile; fileRef = 38C8AC1E246611E500BA7FAA /* RNTesterLoadAllPages.m */; };
 		38CB64352445042D009035CC /* RNTesterTurboModuleProvider.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5CB07C99226467E60039471C /* RNTesterTurboModuleProvider.mm */; };
+		3C3340D75414A4B2BB18F71B /* libPods-macOSBuild.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A407431AB1D73B2E00E5ABF /* libPods-macOSBuild.a */; };
 		3D2AFAF51D646CF80089D1A3 /* legacy_image@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 3D2AFAF41D646CF80089D1A3 /* legacy_image@2x.png */; };
-		406899858FD879C3865516ED /* libPods-RNTester-macOSIntegrationTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2A0E489E2050E6ED99B47F34 /* libPods-RNTester-macOSIntegrationTests.a */; };
-		413F654822EE16AED0DF2540 /* libPods-RNTester.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F94084777080D7B374FB4783 /* libPods-RNTester.a */; };
+		460CE8493C58CA1961711C65 /* libPods-RNTester-macOSUnitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 631E567DA6FC6811984E2E9E /* libPods-RNTester-macOSUnitTests.a */; };
 		5101985723AD9EE600118BF1 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5101985523AD9EE600118BF1 /* Main.storyboard */; };
 		5101985A23AD9F5B00118BF1 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5101985923AD9F5B00118BF1 /* ViewController.m */; };
 		5101985B23ADA00B00118BF1 /* legacy_image@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 3D2AFAF41D646CF80089D1A3 /* legacy_image@2x.png */; };
 		5C60EB1C226440DB0018C04F /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C60EB1B226440DB0018C04F /* AppDelegate.mm */; };
 		5CB07C9B226467E60039471C /* RNTesterTurboModuleProvider.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5CB07C99226467E60039471C /* RNTesterTurboModuleProvider.mm */; };
-		6766440649168A1FAD1DB4A4 /* libPods-RNTesterIntegrationTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F836A7C97EC1BA121BA5A2A /* libPods-RNTesterIntegrationTests.a */; };
+		69BC8E93DA44B97973109653 /* libPods-RNTester.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E8B230FF4022BC6F5F8A1467 /* libPods-RNTester.a */; };
 		8145AE06241172D900A3F8DA /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8145AE05241172D900A3F8DA /* LaunchScreen.storyboard */; };
-		85C7978AB28C149170A56955 /* libPods-RNTesterUnitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 11941849F77C552FDC3EED77 /* libPods-RNTesterUnitTests.a */; };
-		875AA0C43B685DDE9FE6F3A3 /* libPods-RNTester-macOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 858934490E771F8B5402C797 /* libPods-RNTester-macOS.a */; };
-		8BBFF9F061783A02D50DD2EC /* libPods-RNTesterIntegrationTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8210317F3CE28B1945488740 /* libPods-RNTesterIntegrationTests.a */; };
+		84A868BA1CE1467EBC8F4291 /* libPods-RNTesterIntegrationTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A84904C6079328ECC03280D1 /* libPods-RNTesterIntegrationTests.a */; };
+		84C4279B1214742A42EB3568 /* libPods-RNTester-macOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F4FA272D3E8358AEC6A516B9 /* libPods-RNTester-macOS.a */; };
+		8A21778100EA6DC535FC3577 /* libPods-RNTester-macOSIntegrationTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A3D174930AD75B12F47289E6 /* libPods-RNTester-macOSIntegrationTests.a */; };
+		9B4F7CFBFB1B833085A71670 /* libPods-iosSimulatorBuild.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C43F9DC02AAFE8EF86D62D78 /* libPods-iosSimulatorBuild.a */; };
 		9F15345F233AB2C4006DFE44 /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9F15345E233AB2C4006DFE44 /* AppDelegate.mm */; };
 		9F153461233AB2C7006DFE44 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9F153460233AB2C7006DFE44 /* Assets.xcassets */; };
 		9F153467233AB2C7006DFE44 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F153466233AB2C7006DFE44 /* main.m */; };
+		AFC757F10008B167B9DCFD43 /* libPods-iosDeviceBuild.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DDE8ED7D8FB17AFA3F66FF96 /* libPods-iosDeviceBuild.a */; };
 		B2F2040A24E76D7600863BE1 /* ScreenshotMacOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = B2F2040924E76D7600863BE1 /* ScreenshotMacOS.mm */; };
-		E59A0FBD0170A092274A6207 /* libPods-RNTesterUnitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 72247071A1BF06D54F0FECC7 /* libPods-RNTesterUnitTests.a */; };
 		E7C1241A22BEC44B00DA25C0 /* RNTesterIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7C1241922BEC44B00DA25C0 /* RNTesterIntegrationTests.m */; };
 		E7DB20D122B2BAA6005AC45F /* RCTBundleURLProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7DB20A922B2BAA3005AC45F /* RCTBundleURLProviderTests.m */; };
 		E7DB20D222B2BAA6005AC45F /* RCTModuleInitNotificationRaceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7DB20AA22B2BAA3005AC45F /* RCTModuleInitNotificationRaceTests.m */; };
@@ -177,20 +177,18 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		11941849F77C552FDC3EED77 /* libPods-RNTesterUnitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNTesterUnitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07F961A680F5B00A75B9A /* RNTester.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RNTester.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = RNTester/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = RNTester/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = RNTester/main.m; sourceTree = "<group>"; };
+		1ECF206BF13260815AAC95EA /* Pods-iosDeviceBuild.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosDeviceBuild.debug.xcconfig"; path = "Target Support Files/Pods-iosDeviceBuild/Pods-iosDeviceBuild.debug.xcconfig"; sourceTree = "<group>"; };
 		272E6B3B1BEA849E001FCF37 /* UpdatePropertiesExampleView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UpdatePropertiesExampleView.h; path = RNTester/NativeExampleViews/UpdatePropertiesExampleView.h; sourceTree = "<group>"; };
 		272E6B3C1BEA849E001FCF37 /* UpdatePropertiesExampleView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = UpdatePropertiesExampleView.m; path = RNTester/NativeExampleViews/UpdatePropertiesExampleView.m; sourceTree = "<group>"; };
 		27E7277560D64734B4F0E7D9 /* Pods-RNTester-macOSIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNTester-macOSIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-RNTester-macOSIntegrationTests/Pods-RNTester-macOSIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 		27F441E81BEBE5030039B79C /* FlexibleSizeExampleView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FlexibleSizeExampleView.m; path = RNTester/NativeExampleViews/FlexibleSizeExampleView.m; sourceTree = "<group>"; };
 		27F441EA1BEBE5030039B79C /* FlexibleSizeExampleView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FlexibleSizeExampleView.h; path = RNTester/NativeExampleViews/FlexibleSizeExampleView.h; sourceTree = "<group>"; };
-		2A0E489E2050E6ED99B47F34 /* libPods-RNTester-macOSIntegrationTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNTester-macOSIntegrationTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2DDEF00F1F84BF7B00DBDF73 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = RNTester/Images.xcassets; sourceTree = "<group>"; };
 		38360C8B244E7D8B007B212D /* RNTester.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = RNTester.entitlements; path = RNTester/RNTester.entitlements; sourceTree = "<group>"; };
-		383838BF244BC3AE005FAC75 /* libPods-RNTesterUnitTests.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libPods-RNTesterUnitTests.a"; path = "../../../Library/Developer/Xcode/DerivedData/RNTesterPods-bpqvwgykvczlrybljbollkvfwjik/Build/Products/Debug-iphoneos/libPods-RNTesterUnitTests.a"; sourceTree = "<group>"; };
 		383889D923A7398900D06C3E /* RCTConvert_UIColorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTConvert_UIColorTests.m; sourceTree = "<group>"; };
 		387847D1245631D80035033A /* libiosDeviceBuild.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libiosDeviceBuild.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		387847DE245631F50035033A /* libiosSimulatorBuild.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libiosSimulatorBuild.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -202,21 +200,19 @@
 		3CD3706443F2188E09CBF2D2 /* Pods-RNTesterIntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNTesterIntegrationTests.debug.xcconfig"; path = "Target Support Files/Pods-RNTesterIntegrationTests/Pods-RNTesterIntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
 		3D2AFAF41D646CF80089D1A3 /* legacy_image@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "legacy_image@2x.png"; path = "RNTester/legacy_image@2x.png"; sourceTree = "<group>"; };
 		3DC317D3EE16C63CD9243667 /* Pods-RNTester.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNTester.release.xcconfig"; path = "Target Support Files/Pods-RNTester/Pods-RNTester.release.xcconfig"; sourceTree = "<group>"; };
+		50AD031542320BFA83630EDE /* Pods-iosSimulatorBuild.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosSimulatorBuild.release.xcconfig"; path = "Target Support Files/Pods-iosSimulatorBuild/Pods-iosSimulatorBuild.release.xcconfig"; sourceTree = "<group>"; };
 		5101985623AD9EE600118BF1 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		5101985823AD9F5B00118BF1 /* ViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
 		5101985923AD9F5B00118BF1 /* ViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
 		5C60EB1B226440DB0018C04F /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = RNTester/AppDelegate.mm; sourceTree = "<group>"; };
 		5CB07C99226467E60039471C /* RNTesterTurboModuleProvider.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = RNTesterTurboModuleProvider.mm; path = RNTester/RNTesterTurboModuleProvider.mm; sourceTree = "<group>"; };
 		5CB07C9A226467E60039471C /* RNTesterTurboModuleProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RNTesterTurboModuleProvider.h; path = RNTester/RNTesterTurboModuleProvider.h; sourceTree = "<group>"; };
-		5F836A7C97EC1BA121BA5A2A /* libPods-RNTesterIntegrationTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNTesterIntegrationTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		604873ABF80DC3EE97E87CCF /* Pods-RNTester-macOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNTester-macOS.release.xcconfig"; path = "Target Support Files/Pods-RNTester-macOS/Pods-RNTester-macOS.release.xcconfig"; sourceTree = "<group>"; };
+		631E567DA6FC6811984E2E9E /* libPods-RNTester-macOSUnitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNTester-macOSUnitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6A407431AB1D73B2E00E5ABF /* libPods-macOSBuild.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-macOSBuild.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6D3E7ECE8F9BEC26E5786555 /* Pods-RNTester.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNTester.debug.xcconfig"; path = "Target Support Files/Pods-RNTester/Pods-RNTester.debug.xcconfig"; sourceTree = "<group>"; };
-		72247071A1BF06D54F0FECC7 /* libPods-RNTesterUnitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNTesterUnitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		7DBA22D1B717C9D2E9B00E92 /* libPods-RNTester-macOSUnitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNTester-macOSUnitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8145AE05241172D900A3F8DA /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = RNTester/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		8210317F3CE28B1945488740 /* libPods-RNTesterIntegrationTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNTesterIntegrationTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		821937C864FDA0F3C485B4A6 /* Pods-RNTester-macOSUnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNTester-macOSUnitTests.release.xcconfig"; path = "Target Support Files/Pods-RNTester-macOSUnitTests/Pods-RNTester-macOSUnitTests.release.xcconfig"; sourceTree = "<group>"; };
-		858934490E771F8B5402C797 /* libPods-RNTester-macOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNTester-macOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8735BC063632C9712E25C7D9 /* Pods-RNTesterUnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNTesterUnitTests.release.xcconfig"; path = "Target Support Files/Pods-RNTesterUnitTests/Pods-RNTesterUnitTests.release.xcconfig"; sourceTree = "<group>"; };
 		87D5D06CD6060D32601A10DD /* Pods-RNTester-macOSUnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNTester-macOSUnitTests.debug.xcconfig"; path = "Target Support Files/Pods-RNTester-macOSUnitTests/Pods-RNTester-macOSUnitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		9F15345B233AB2C4006DFE44 /* RNTester-macOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "RNTester-macOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -232,11 +228,17 @@
 		9F153478233AB2C7006DFE44 /* RNTester-macOSIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RNTester-macOSIntegrationTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9F15347C233AB2C7006DFE44 /* RNTesterIntegrationTests_macOS.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNTesterIntegrationTests_macOS.m; sourceTree = "<group>"; };
 		9F15347E233AB2C7006DFE44 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A3D174930AD75B12F47289E6 /* libPods-RNTester-macOSIntegrationTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNTester-macOSIntegrationTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A84904C6079328ECC03280D1 /* libPods-RNTesterIntegrationTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNTesterIntegrationTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		AB0102C840930F7AC64C3D36 /* libPods-RNTesterUnitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNTesterUnitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		ABC5325C94F71908317C26A8 /* Pods-macOSBuild.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-macOSBuild.debug.xcconfig"; path = "Target Support Files/Pods-macOSBuild/Pods-macOSBuild.debug.xcconfig"; sourceTree = "<group>"; };
+		AC6DB4C70AE6C558CFE78E9D /* Pods-iosDeviceBuild.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosDeviceBuild.release.xcconfig"; path = "Target Support Files/Pods-iosDeviceBuild/Pods-iosDeviceBuild.release.xcconfig"; sourceTree = "<group>"; };
 		AFC451B51B7D6F0C1CAD0C18 /* Pods-RNTester-macOSIntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNTester-macOSIntegrationTests.debug.xcconfig"; path = "Target Support Files/Pods-RNTester-macOSIntegrationTests/Pods-RNTester-macOSIntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
 		B2F2040824E76D7600863BE1 /* ScreenshotMacOS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ScreenshotMacOS.h; path = NativeModuleExample/ScreenshotMacOS.h; sourceTree = SOURCE_ROOT; };
 		B2F2040924E76D7600863BE1 /* ScreenshotMacOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ScreenshotMacOS.mm; path = NativeModuleExample/ScreenshotMacOS.mm; sourceTree = SOURCE_ROOT; };
-		B5C8E567A4E6281113811CB1 /* libPods-RNTester.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNTester.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C38CB0C2095A8FFDE13321E5 /* Pods-RNTesterUnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNTesterUnitTests.debug.xcconfig"; path = "Target Support Files/Pods-RNTesterUnitTests/Pods-RNTesterUnitTests.debug.xcconfig"; sourceTree = "<group>"; };
+		C43F9DC02AAFE8EF86D62D78 /* libPods-iosSimulatorBuild.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-iosSimulatorBuild.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		DDE8ED7D8FB17AFA3F66FF96 /* libPods-iosDeviceBuild.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-iosDeviceBuild.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E68A0B7D2448B4F300228B0B /* RNTesterUnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RNTesterUnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E771AEEA22B44E3100EA1189 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = RNTester/Info.plist; sourceTree = "<group>"; };
 		E7C1241922BEC44B00DA25C0 /* RNTesterIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNTesterIntegrationTests.m; sourceTree = "<group>"; };
@@ -310,8 +312,11 @@
 		E7DB216122B2F3EC005AC45F /* RCTRootViewIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTRootViewIntegrationTests.m; sourceTree = "<group>"; };
 		E7DB218B22B41FCD005AC45F /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		E88C98CC10E157202A961408 /* Pods-RNTesterIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNTesterIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-RNTesterIntegrationTests/Pods-RNTesterIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
+		E8B230FF4022BC6F5F8A1467 /* libPods-RNTester.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNTester.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E9CE1968E72EB97B674E80A4 /* Pods-RNTester-macOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNTester-macOS.debug.xcconfig"; path = "Target Support Files/Pods-RNTester-macOS/Pods-RNTester-macOS.debug.xcconfig"; sourceTree = "<group>"; };
-		F94084777080D7B374FB4783 /* libPods-RNTester.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNTester.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F4FA272D3E8358AEC6A516B9 /* libPods-RNTester-macOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNTester-macOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F7DC249273A51CC8A56ED858 /* Pods-macOSBuild.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-macOSBuild.release.xcconfig"; path = "Target Support Files/Pods-macOSBuild/Pods-macOSBuild.release.xcconfig"; sourceTree = "<group>"; };
+		FEC7DFC73F5A7055398F11B6 /* Pods-iosSimulatorBuild.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosSimulatorBuild.debug.xcconfig"; path = "Target Support Files/Pods-iosSimulatorBuild/Pods-iosSimulatorBuild.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -319,7 +324,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				413F654822EE16AED0DF2540 /* libPods-RNTester.a in Frameworks */,
+				69BC8E93DA44B97973109653 /* libPods-RNTester.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -327,6 +332,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AFC757F10008B167B9DCFD43 /* libPods-iosDeviceBuild.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -334,6 +340,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9B4F7CFBFB1B833085A71670 /* libPods-iosSimulatorBuild.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -341,6 +348,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3C3340D75414A4B2BB18F71B /* libPods-macOSBuild.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -348,7 +356,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				875AA0C43B685DDE9FE6F3A3 /* libPods-RNTester-macOS.a in Frameworks */,
+				84C4279B1214742A42EB3568 /* libPods-RNTester-macOS.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -357,7 +365,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				38BB7CD524455EDD00803CDE /* OCMock.framework in Frameworks */,
-				28A91DB1D5B44426DC1C8516 /* libPods-RNTester-macOSUnitTests.a in Frameworks */,
+				460CE8493C58CA1961711C65 /* libPods-RNTester-macOSUnitTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -365,7 +373,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				406899858FD879C3865516ED /* libPods-RNTester-macOSIntegrationTests.a in Frameworks */,
+				8A21778100EA6DC535FC3577 /* libPods-RNTester-macOSIntegrationTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -373,11 +381,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				383838C0244BC3BD005FAC75 /* libPods-RNTesterUnitTests.a in Frameworks */,
 				383838C1244BC3D9005FAC75 /* JavaScriptCore.framework in Frameworks */,
 				38A9383C244532470025DABB /* libOCMock.a in Frameworks */,
-				E59A0FBD0170A092274A6207 /* libPods-RNTesterUnitTests.a in Frameworks */,
-				85C7978AB28C149170A56955 /* libPods-RNTesterUnitTests.a in Frameworks */,
+				087CFC06CF5A5AA9DBB32BE2 /* libPods-RNTesterUnitTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -387,8 +393,7 @@
 			files = (
 				E7DB218C22B41FCD005AC45F /* XCTest.framework in Frameworks */,
 				E7DB216722B2F69F005AC45F /* JavaScriptCore.framework in Frameworks */,
-				8BBFF9F061783A02D50DD2EC /* libPods-RNTesterIntegrationTests.a in Frameworks */,
-				6766440649168A1FAD1DB4A4 /* libPods-RNTesterIntegrationTests.a in Frameworks */,
+				84A868BA1CE1467EBC8F4291 /* libPods-RNTesterIntegrationTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -459,16 +464,15 @@
 				E7DB211822B2BD53005AC45F /* libReact-RCTText.a */,
 				E7DB211A22B2BD53005AC45F /* libReact-RCTVibration.a */,
 				E7DB212222B2BD53005AC45F /* libyoga.a */,
-				F94084777080D7B374FB4783 /* libPods-RNTester.a */,
-				8210317F3CE28B1945488740 /* libPods-RNTesterIntegrationTests.a */,
-				72247071A1BF06D54F0FECC7 /* libPods-RNTesterUnitTests.a */,
-				383838BF244BC3AE005FAC75 /* libPods-RNTesterUnitTests.a */,
-				B5C8E567A4E6281113811CB1 /* libPods-RNTester.a */,
-				5F836A7C97EC1BA121BA5A2A /* libPods-RNTesterIntegrationTests.a */,
-				11941849F77C552FDC3EED77 /* libPods-RNTesterUnitTests.a */,
-				858934490E771F8B5402C797 /* libPods-RNTester-macOS.a */,
-				2A0E489E2050E6ED99B47F34 /* libPods-RNTester-macOSIntegrationTests.a */,
-				7DBA22D1B717C9D2E9B00E92 /* libPods-RNTester-macOSUnitTests.a */,
+				E8B230FF4022BC6F5F8A1467 /* libPods-RNTester.a */,
+				F4FA272D3E8358AEC6A516B9 /* libPods-RNTester-macOS.a */,
+				A3D174930AD75B12F47289E6 /* libPods-RNTester-macOSIntegrationTests.a */,
+				631E567DA6FC6811984E2E9E /* libPods-RNTester-macOSUnitTests.a */,
+				A84904C6079328ECC03280D1 /* libPods-RNTesterIntegrationTests.a */,
+				AB0102C840930F7AC64C3D36 /* libPods-RNTesterUnitTests.a */,
+				DDE8ED7D8FB17AFA3F66FF96 /* libPods-iosDeviceBuild.a */,
+				C43F9DC02AAFE8EF86D62D78 /* libPods-iosSimulatorBuild.a */,
+				6A407431AB1D73B2E00E5ABF /* libPods-macOSBuild.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -559,6 +563,12 @@
 				27E7277560D64734B4F0E7D9 /* Pods-RNTester-macOSIntegrationTests.release.xcconfig */,
 				87D5D06CD6060D32601A10DD /* Pods-RNTester-macOSUnitTests.debug.xcconfig */,
 				821937C864FDA0F3C485B4A6 /* Pods-RNTester-macOSUnitTests.release.xcconfig */,
+				1ECF206BF13260815AAC95EA /* Pods-iosDeviceBuild.debug.xcconfig */,
+				AC6DB4C70AE6C558CFE78E9D /* Pods-iosDeviceBuild.release.xcconfig */,
+				FEC7DFC73F5A7055398F11B6 /* Pods-iosSimulatorBuild.debug.xcconfig */,
+				50AD031542320BFA83630EDE /* Pods-iosSimulatorBuild.release.xcconfig */,
+				ABC5325C94F71908317C26A8 /* Pods-macOSBuild.debug.xcconfig */,
+				F7DC249273A51CC8A56ED858 /* Pods-macOSBuild.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -658,8 +668,8 @@
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				68CD48B71D2BCB2C007E06A9 /* Build JS Bundle */,
 				5CF0FD27207FC6EC00C13D65 /* Start Metro */,
-				8BA2D8960038381F0B753726 /* [CP] Copy Pods Resources */,
 				59FB8E2EE11176798F1F79BF /* [CP] Embed Pods Frameworks */,
+				876175BE889FD351D8E77AC9 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -674,6 +684,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 387847D7245631D80035033A /* Build configuration list for PBXNativeTarget "iosDeviceBuild" */;
 			buildPhases = (
+				77A2E97C65AABD4BA2F6F29B /* [CP] Check Pods Manifest.lock */,
 				387847CD245631D80035033A /* Sources */,
 				387847CE245631D80035033A /* Frameworks */,
 				387847CF245631D80035033A /* CopyFiles */,
@@ -691,6 +702,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 387847E4245631F50035033A /* Build configuration list for PBXNativeTarget "iosSimulatorBuild" */;
 			buildPhases = (
+				C55342180F72D0025E2DD28C /* [CP] Check Pods Manifest.lock */,
 				387847DA245631F50035033A /* Sources */,
 				387847DB245631F50035033A /* Frameworks */,
 				387847DC245631F50035033A /* CopyFiles */,
@@ -708,6 +720,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 387847F12456320C0035033A /* Build configuration list for PBXNativeTarget "macOSBuild" */;
 			buildPhases = (
+				10AB8F2FA248D122E5FC5D4C /* [CP] Check Pods Manifest.lock */,
 				26905525A793EABD06A4E9DD /* Start Metro */,
 				387847E72456320C0035033A /* Headers */,
 				387847E82456320C0035033A /* Sources */,
@@ -732,7 +745,7 @@
 				9F153459233AB2C4006DFE44 /* Resources */,
 				38C8132424577FB500BFFA62 /* Build JS Bundle */,
 				51B9D81723C4D5A4002B30E1 /* Start Metro */,
-				B6D35C15502611CA65A391E6 /* [CP] Copy Pods Resources */,
+				170C222AF602946553790BB0 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -752,7 +765,7 @@
 				9F15346A233AB2C7006DFE44 /* Frameworks */,
 				9F15346B233AB2C7006DFE44 /* Resources */,
 				3882C0E12445655100E92FB9 /* Copy Files (1 item) */,
-				A2885E91CCED3B7CB66D4BC2 /* [CP] Copy Pods Resources */,
+				6AFB016C9B7463C62B44F318 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -772,7 +785,7 @@
 				9F153474233AB2C7006DFE44 /* Sources */,
 				9F153475233AB2C7006DFE44 /* Frameworks */,
 				9F153476233AB2C7006DFE44 /* Resources */,
-				ADEE8D12405750DEF58D70D1 /* [CP] Copy Pods Resources */,
+				90DA0640700ADDD73F8842BD /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -792,7 +805,7 @@
 				E7DB209B22B2BA84005AC45F /* Sources */,
 				E7DB209C22B2BA84005AC45F /* Frameworks */,
 				E7DB209D22B2BA84005AC45F /* Resources */,
-				D3E745B9771EC6F02AC52196 /* [CP] Copy Pods Resources */,
+				66536E8DF39B47627A510DF1 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -812,7 +825,7 @@
 				E7DB214F22B2F332005AC45F /* Sources */,
 				E7DB215022B2F332005AC45F /* Frameworks */,
 				E7DB215122B2F332005AC45F /* Resources */,
-				186E435C9BE5B7CC0656A19C /* [CP] Copy Pods Resources */,
+				A0F82A7ABB9969342057CBE1 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -945,21 +958,43 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		186E435C9BE5B7CC0656A19C /* [CP] Copy Pods Resources */ = {
+		10AB8F2FA248D122E5FC5D4C /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RNTesterIntegrationTests/Pods-RNTesterIntegrationTests-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			name = "[CP] Copy Pods Resources";
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RNTesterIntegrationTests/Pods-RNTesterIntegrationTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-macOSBuild-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RNTesterIntegrationTests/Pods-RNTesterIntegrationTests-resources.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		170C222AF602946553790BB0 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RNTester-macOS/Pods-RNTester-macOS-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RNTester-macOS/Pods-RNTester-macOS-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RNTester-macOS/Pods-RNTester-macOS-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		1FD7CC5A44DCEE15C8D13E0A /* [CP] Check Pods Manifest.lock */ = {
@@ -1113,6 +1148,23 @@
 			shellScript = "export RCT_METRO_PORT=\"${RCT_METRO_PORT:=8081}\"\necho \"export RCT_METRO_PORT=${RCT_METRO_PORT}\" > \"${SRCROOT}/../../scripts/.packager.env\"\nif [ -z \"${RCT_NO_LAUNCH_PACKAGER+xxx}\" ] ; then\n  if nc -w 5 -z localhost ${RCT_METRO_PORT} ; then\n    if ! curl -s \"http://localhost:${RCT_METRO_PORT}/status\" | grep -q \"packager-status:running\" ; then\n      echo \"Port ${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\"\n      exit 2\n    fi\n  else\n    open \"$SRCROOT/../../scripts/launchPackager.command\" || echo \"Can't start packager automatically\"\n  fi\nfi\n";
 			showEnvVarsInLog = 0;
 		};
+		66536E8DF39B47627A510DF1 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RNTesterUnitTests/Pods-RNTesterUnitTests-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RNTesterUnitTests/Pods-RNTesterUnitTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RNTesterUnitTests/Pods-RNTesterUnitTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		68CD48B71D2BCB2C007E06A9 /* Build JS Bundle */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1127,7 +1179,46 @@
 			shellPath = /bin/sh;
 			shellScript = "export NODE_BINARY=node\nexport PROJECT_ROOT=$SRCROOT/../..\nexport SOURCEMAP_FILE=../../sourcemap.ios.map\n# export FORCE_BUNDLING=true\n\"$SRCROOT/../../scripts/react-native-xcode.sh\" packages/rn-tester/js/RNTesterApp.ios.js\n";
 		};
-		8BA2D8960038381F0B753726 /* [CP] Copy Pods Resources */ = {
+		6AFB016C9B7463C62B44F318 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RNTester-macOSUnitTests/Pods-RNTester-macOSUnitTests-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RNTester-macOSUnitTests/Pods-RNTester-macOSUnitTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RNTester-macOSUnitTests/Pods-RNTester-macOSUnitTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		77A2E97C65AABD4BA2F6F29B /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-iosDeviceBuild-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		876175BE889FD351D8E77AC9 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1142,6 +1233,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RNTester/Pods-RNTester-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		90DA0640700ADDD73F8842BD /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RNTester-macOSIntegrationTests/Pods-RNTester-macOSIntegrationTests-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RNTester-macOSIntegrationTests/Pods-RNTester-macOSIntegrationTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RNTester-macOSIntegrationTests/Pods-RNTester-macOSIntegrationTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		9F8B51C0405957F2A7BE3F54 /* [CP] Check Pods Manifest.lock */ = {
@@ -1166,21 +1274,21 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		A2885E91CCED3B7CB66D4BC2 /* [CP] Copy Pods Resources */ = {
+		A0F82A7ABB9969342057CBE1 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RNTester-macOSUnitTests/Pods-RNTester-macOSUnitTests-resources-${CONFIGURATION}-input-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-RNTesterIntegrationTests/Pods-RNTesterIntegrationTests-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RNTester-macOSUnitTests/Pods-RNTester-macOSUnitTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-RNTesterIntegrationTests/Pods-RNTesterIntegrationTests-resources-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RNTester-macOSUnitTests/Pods-RNTester-macOSUnitTests-resources.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RNTesterIntegrationTests/Pods-RNTesterIntegrationTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		A7D95A9E84DEB30F42E4B186 /* [CP] Check Pods Manifest.lock */ = {
@@ -1205,55 +1313,26 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		ADEE8D12405750DEF58D70D1 /* [CP] Copy Pods Resources */ = {
+		C55342180F72D0025E2DD28C /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RNTester-macOSIntegrationTests/Pods-RNTester-macOSIntegrationTests-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			name = "[CP] Copy Pods Resources";
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RNTester-macOSIntegrationTests/Pods-RNTester-macOSIntegrationTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-iosSimulatorBuild-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RNTester-macOSIntegrationTests/Pods-RNTester-macOSIntegrationTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		B6D35C15502611CA65A391E6 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RNTester-macOS/Pods-RNTester-macOS-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RNTester-macOS/Pods-RNTester-macOS-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RNTester-macOS/Pods-RNTester-macOS-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		D3E745B9771EC6F02AC52196 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RNTesterUnitTests/Pods-RNTesterUnitTests-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RNTesterUnitTests/Pods-RNTesterUnitTests-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RNTesterUnitTests/Pods-RNTesterUnitTests-resources.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		D9BE43355C8C29497EED268E /* [CP] Check Pods Manifest.lock */ = {
@@ -1546,6 +1625,7 @@
 		};
 		387847D8245631D80035033A /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1ECF206BF13260815AAC95EA /* Pods-iosDeviceBuild.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -1569,6 +1649,7 @@
 		};
 		387847D9245631D80035033A /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = AC6DB4C70AE6C558CFE78E9D /* Pods-iosDeviceBuild.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -1592,6 +1673,7 @@
 		};
 		387847E5245631F50035033A /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = FEC7DFC73F5A7055398F11B6 /* Pods-iosSimulatorBuild.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -1615,6 +1697,7 @@
 		};
 		387847E6245631F50035033A /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 50AD031542320BFA83630EDE /* Pods-iosSimulatorBuild.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -1638,6 +1721,7 @@
 		};
 		387847F22456320C0035033A /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = ABC5325C94F71908317C26A8 /* Pods-macOSBuild.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -1662,6 +1746,7 @@
 		};
 		387847F32456320C0035033A /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F7DC249273A51CC8A56ED858 /* Pods-macOSBuild.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -1721,7 +1806,7 @@
 				ENABLE_BITCODE = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -1805,7 +1890,7 @@
 				ENABLE_BITCODE = NO;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_TREAT_INCOMPATIBLE_POINTER_TYPE_WARNINGS_AS_ERRORS = YES;

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -248,5 +248,5 @@ def __apply_Xcode_12_5_M1_post_install_workaround(installer)
   #   "Time.h:52:17: error: typedef redefinition with different types"
   # We need to make a patch to RCT-Folly - set `__IPHONE_10_0` to our iOS target + 1.
   # See https://github.com/facebook/flipper/issues/834 for more details.
-  `sed -i -e  $'s/__IPHONE_10_0/__IPHONE_12_0/' #{installer.sandbox.root}/RCT-Folly/folly/portability/Time.h`
+  `sed -i -e  $'s/VERSION_MIN_REQUIRED </VERSION_MIN_REQUIRED >=/' #{installer.sandbox.root}/RCT-Folly/folly/portability/Time.h`
 end


### PR DESCRIPTION
Get RNTester compiling for macOS.

Most of these changes are pretty straightforward (such as replacing `UIColor` with `RCTUIColor`).

This does not guarantee that RNTester will run without any issues. This will come with a later PR.