### PR TITLE
Fix invocation of bump-oss-version.js in react-native-macos-init.yml

### DIFF
--- a/.ado/templates/react-native-macos-init.yml
+++ b/.ado/templates/react-native-macos-init.yml
@@ -59,7 +59,7 @@ steps:
   - task: CmdLine@2
     displayName: Bump package version
     inputs:
-      script: node scripts/bump-oss-version.js --ci 0.0.1000
+      script: node scripts/bump-oss-version.js -v 0.0.1000
 
   - script: |
       npm publish --registry http://localhost:4873


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Fix invocation of scripts/bump-oss-version.js in react-native-macos-init.yml.

The version of scripts/bump-oss-version.js as shown [here](https://github.com/microsoft/react-native-macos/pull/977/commits/6f1805279563332f52a86871410108f7fea813ef#diff-902c6baeef2d1fb600e749f14f1ebdd3dd6270c7f7a6feede0984e8b5e268dcc) makes two changes:
* The version number we're trying to upgrade to must now come after a `-v` flag.
* We no longer look for a `--ci` flag.

The second point isn't as important, but the first one has caused a failure in our automated checks to get this working. This should fix things.